### PR TITLE
Feature/adc read extended

### DIFF
--- a/esp32/Proyecto-MQTT/main/i2c_master.c
+++ b/esp32/Proyecto-MQTT/main/i2c_master.c
@@ -1,0 +1,53 @@
+// EJERCICIO EF11
+// MSEEI-UMA
+
+
+#include "driver/i2c.h"
+#include "esp_err.h"
+
+static int _i2c_master_port=-1;
+
+// FUNCI�N para CONFIGURACI�N e INSTALACI�N del DRIVER I2C ESP32
+esp_err_t i2c_master_init(int i2c_master_port, gpio_num_t sda_io_num,
+                                    gpio_num_t scl_io_num,  gpio_pullup_t pull_up_en, bool fastMode)
+{
+
+	if (_i2c_master_port < 0)
+	{
+		i2c_config_t conf = {
+
+				.mode = I2C_MODE_MASTER,
+				.sda_io_num = sda_io_num,
+				.sda_pullup_en = pull_up_en,
+				.scl_io_num = scl_io_num,
+				.scl_pullup_en = pull_up_en,
+				.master.clk_speed = fastMode ? 400000 : 100000
+		};
+
+		i2c_param_config(i2c_master_port, &conf);
+		esp_err_t err=i2c_driver_install(i2c_master_port, conf.mode, 0, 0, 0);
+		if (err==0)
+		{
+				_i2c_master_port=i2c_master_port;
+				//err=i2c_set_timeout(i2c_master_port, 1000000);
+		}
+
+	    return err;
+	}
+	else
+	{
+		if (_i2c_master_port==i2c_master_port)
+			return 0; //puerto ya inicializado antes....
+		else
+			return -1; //otro puerto inicializado antes, devuelve error....(control de errores basico podria mejorar)
+	}
+}
+
+ // FUNCI�N de CIERRE del DRIVER I2C ESP32
+esp_err_t i2c_master_close(void)
+{
+
+	esp_err_t err=i2c_driver_delete(_i2c_master_port);
+	_i2c_master_port=-1;
+	return err;
+}

--- a/esp32/Proyecto-MQTT/main/i2c_master.h
+++ b/esp32/Proyecto-MQTT/main/i2c_master.h
@@ -1,0 +1,15 @@
+// EJERCICIO EF11
+// MSEEI-UMA
+#ifndef MAIN_I2C_MASTER_H_
+#define MAIN_I2C_MASTER_H_
+
+#include "driver/i2c.h"
+#include "esp_err.h"
+
+extern esp_err_t i2c_master_init(int i2c_master_port, gpio_num_t sda_io_num,
+                                    gpio_num_t scl_io_num,  gpio_pullup_t pull_up_en, bool fastMode);
+
+
+extern esp_err_t i2c_master_close(void);
+
+#endif /* MAIN_I2C_MASTER_H_ */

--- a/esp32/Proyecto-MQTT/main/lvgl_demo_ui.c
+++ b/esp32/Proyecto-MQTT/main/lvgl_demo_ui.c
@@ -9,7 +9,6 @@
 #include "lvgl.h"
 #include "bsp/esp-bsp.h"
 #include "freertos/semphr.h"
-#include "freertos/queue.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
@@ -69,7 +68,12 @@ void ui_example_lvgl_demo_init(lv_disp_t *disp)
 {
 	// Inicialización del semáforo:
 
-	lcdSemaphoreHandler = xSemaphoreCreateBinary(); // Se crea el semáforo pero no se libera hasta el final de la tarea
+	lcdSemaphoreHandler = xSemaphoreCreateMutex(); // Se crea el semáforo pero no se libera hasta el final de la tarea
+
+	if (lcdSemaphoreHandler == NULL)
+	{
+		while (1);
+	}
 
     lv_obj_t *scr = lv_disp_get_scr_act(disp);
 

--- a/esp32/Proyecto-MQTT/main/lvgl_demo_ui.h
+++ b/esp32/Proyecto-MQTT/main/lvgl_demo_ui.h
@@ -14,5 +14,10 @@ extern void ui_update_clock(uint8_t hout, uint8_t minute, uint8_t second );
 extern void ui_example_lvgl_demo_init(lv_disp_t *disp);
 extern void ui_set_indicator_value(float value);
 
+// Control de LEDs
+extern void ui_set_red_led_on(void);
+extern void ui_set_red_led_off(void);
+extern void ui_toggle_blue_led(void);
+
 
 #endif /* MAIN_LVGL_DEMO_UI_H_ */

--- a/pc-interface/src/guipanel.cpp
+++ b/pc-interface/src/guipanel.cpp
@@ -33,6 +33,7 @@ GUIPanel::GUIPanel(QWidget *parent) :  // Constructor de la clase
     pingRequest = false;             // No se ha hecho solicitud de PING.
     updatingPWMControlInternally = false; // flag de actualización de controles de LED internos.
     updatingTemperatureControlInternally = false; // Flag de actualización de controles de temperatura internos.
+    adcEnable = false;                            // Flag de habilitación de lectura del ADC
 
     // Se oculta el control PWM de los LED en el arranque
     ui->Knob->setHidden(true);
@@ -305,6 +306,19 @@ void GUIPanel::onMQTT_Received(const QMQTT::Message &message)
                             ui->Counter->setValue(measure_time);
                         }
                         updatingTemperatureControlInternally = false;
+                    }
+                    else if ((keys[i] == "adc_enable") && (entrada.isBool()))
+                    {
+                        adcEnable = entrada.toBool();
+
+                        if (adcEnable)
+                        {
+                            ui->pushButton_8->setText("ENABLED");
+                        }
+                        else
+                        {
+                            ui->pushButton_8->setText("DISABLED");
+                        }
                     }
                     else
                     {
@@ -608,6 +622,26 @@ void GUIPanel::on_Counter_valueChanged(double value)
 
     if (updatingTemperatureControlInternally) // Para evitar que se envíe repetido un nuevo cambio en la checkbox cuando se está recibiendo el cambio por MQTT
         return;
+
+    SendMessage_General(objeto_json);
+}
+
+void GUIPanel::on_pushButton_8_clicked(void)
+{
+    QJsonObject objeto_json;
+
+    adcEnable = !adcEnable;
+
+    if (adcEnable)
+    {
+        ui->pushButton_8->setText("ENABLED");
+    }
+    else
+    {
+        ui->pushButton_8->setText("DISABLED");
+    }
+
+    objeto_json["adc_enable"] = adcEnable;
 
     SendMessage_General(objeto_json);
 }

--- a/pc-interface/src/guipanel.h
+++ b/pc-interface/src/guipanel.h
@@ -63,6 +63,8 @@ private slots:
 
     void on_Counter_valueChanged(double value);
 
+    void on_pushButton_8_clicked(void);
+
 private: // funciones privadas
 //    void pingDevice();
     void startClient();
@@ -79,6 +81,7 @@ private:
     bool pingRequest;
     bool updatingPWMControlInternally;
     bool updatingTemperatureControlInternally;
+    bool adcEnable;
     QString suscribeRootTopic;
     QString publishRootTopic;
 

--- a/pc-interface/src/guipanel.ui
+++ b/pc-interface/src/guipanel.ui
@@ -133,12 +133,12 @@
     <rect>
      <x>10</x>
      <y>110</y>
-     <width>691</width>
+     <width>751</width>
      <height>261</height>
     </rect>
    </property>
    <property name="currentIndex">
-    <number>0</number>
+    <number>2</number>
    </property>
    <widget class="QWidget" name="LED_tab">
     <attribute name="title">
@@ -399,11 +399,24 @@
     <widget class="QwtPlot" name="qwtPlot">
      <property name="geometry">
       <rect>
-       <x>49</x>
+       <x>0</x>
        <y>20</y>
        <width>551</width>
        <height>200</height>
       </rect>
+     </property>
+    </widget>
+    <widget class="QPushButton" name="pushButton_8">
+     <property name="geometry">
+      <rect>
+       <x>582</x>
+       <y>90</y>
+       <width>131</width>
+       <height>29</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>DISABLED</string>
      </property>
     </widget>
    </widget>


### PR DESCRIPTION
ESP32:
- Add MQTT command reception capabilities for ADC enable/disable feature.
- Add semaphore to ADC read task to ensure the task is suspended when disabled.
- Add LCD "LED" control routines for RED and BLUE LEDs on ui library
- Add "LED" routine calls to turn on red "LED" when reading is enabled, otherwise "LED" is turned off.
- Add "LED" routine call to toggle blue "LED" when one read process is performed.
- Add semaphore control on ui task to ensure only one task accesses the lvgl library at a time.

GUI:
- Add push button to enable/disable ADC task.
- Add MQTT message send when enable/disable button is pushed.
- Add MQTT message reception capability to ensure all GUI instances are synchronised.