### PR TITLE
Feature/ble scan

### DIFF
--- a/esp32/Proyecto-MQTT/main/lvgl_demo_ui.c
+++ b/esp32/Proyecto-MQTT/main/lvgl_demo_ui.c
@@ -31,6 +31,7 @@ static SemaphoreHandle_t lcdSemaphoreHandler;
 // Variables globales para los LED
 static lv_obj_t * led1; // LED rojo
 static lv_obj_t * led2; // LED azul
+static lv_obj_t * led3; // LED verde
 static bool blueLedStatus;
 
 
@@ -186,7 +187,7 @@ void ui_example_lvgl_demo_init(lv_disp_t *disp)
     blueLedStatus = false;
 
 
-    lv_obj_t * led3  = lv_led_create(cont2);
+    led3  = lv_led_create(cont2);
     lv_obj_center(led3);
     lv_led_set_color(led3, lv_palette_main(LV_PALETTE_GREEN));
     lv_led_off(led3);
@@ -227,5 +228,19 @@ void ui_toggle_blue_led(void)
 		lv_led_on(led2);
 	}
 	blueLedStatus = !blueLedStatus;
+	xSemaphoreGive(lcdSemaphoreHandler);
+}
+
+void ui_set_green_led_on(void)
+{
+	xSemaphoreTake(lcdSemaphoreHandler, portMAX_DELAY);
+	lv_led_on(led3);
+	xSemaphoreGive(lcdSemaphoreHandler);
+}
+
+void ui_set_green_led_off(void)
+{
+	xSemaphoreTake(lcdSemaphoreHandler, portMAX_DELAY);
+	lv_led_off(led3);
 	xSemaphoreGive(lcdSemaphoreHandler);
 }

--- a/esp32/Proyecto-MQTT/main/lvgl_demo_ui.h
+++ b/esp32/Proyecto-MQTT/main/lvgl_demo_ui.h
@@ -18,6 +18,8 @@ extern void ui_set_indicator_value(float value);
 extern void ui_set_red_led_on(void);
 extern void ui_set_red_led_off(void);
 extern void ui_toggle_blue_led(void);
+extern void ui_set_green_led_on(void);
+extern void ui_set_green_led_off(void);
 
 
 #endif /* MAIN_LVGL_DEMO_UI_H_ */

--- a/esp32/Proyecto-MQTT/main/mqtt.c
+++ b/esp32/Proyecto-MQTT/main/mqtt.c
@@ -23,6 +23,7 @@
 #include "mqtt.h"
 #include "lvgl_demo_ui.h"
 #include "ds1621driver.h"
+#include "bluetooth.h"
 
 //FROZEN JSON parsing/fotmatting library header
 #include "frozen.h"
@@ -31,41 +32,19 @@
 //      DEFINES
 //****************************************************************************
 
-#define PONG_TOPIC        "/pong"
-#define POLL_TOPIC        "/button_poll"
-#define ADC_TOPIC         "/adc_read"
-#define LAST_WILL_TOPIC   "/last_will"
-#define TEMPERATURE_TOPIC "/temperature"
+#define PONG_TOPIC             "/pong"
+#define POLL_TOPIC             "/button_poll"
+#define ADC_TOPIC              "/adc_read"
+#define LAST_WILL_TOPIC        "/last_will"
+#define TEMPERATURE_TOPIC      "/temperature"
+#define BLUETOOTH_DEVICE_TOPIC "/bt_device"
 
 #define BOTON_IZQUIERDO  0u
 #define BOTON_DERECHO    1u
 
-#define LAST_WILL_LENGTH 26u
+#define LAST_WILL_LENGTH   26u
 
 #define ADC_SAMPLE_PERIOD 0.2f
-
-//****************************************************************************
-//      TIPOS DE DATOS
-//****************************************************************************
-
-typedef enum{
-    PING,
-    BUTTON_STATUS,
-    ADC_READ,
-    LAST_WILL_MESSAGE,
-	TEMPERATURE_READ
-}mqtt_sendType_t;
-
-typedef enum{
-    LED_ROJO,
-    LED_VERDE,
-    LED_AZUL
-} rgb_colourIndex_t;
-
-typedef struct{
-    mqtt_sendType_t messageType;
-    char payload[128];
-}mqtt_send_t; // Tipo de datos para comunicar al hilo de envío de datos el tipo de mensaje y su payload.
 
 //****************************************************************************
 //      VARIABLES GLOBALES STATIC
@@ -76,13 +55,19 @@ static esp_mqtt_client_handle_t client=NULL;
 static TaskHandle_t senderTaskHandler=NULL;
 static TaskHandle_t adcTaskHandler = NULL;
 static TaskHandle_t temperatureTaskHandler = NULL;
-static QueueHandle_t sendQueueHandler=NULL;
 static QueueHandle_t temperatureQueueHandler=NULL;
 static SemaphoreHandle_t adcSemaphoreHandler;
 static uint8_t rgbPwmValues[3] = {0};
 static uint8_t binaryLEDValues[3] = {0};
 static bool botonIzquierdo, botonDerecho;
 static volatile mqtt_send_t estadoBotonesISR;
+
+
+//****************************************************************************
+//      VARIABLES COMPARTIDAS EXTERN
+//****************************************************************************
+
+QueueHandle_t sendQueueHandler=NULL;
 
 //****************************************************************************
 // Funciones.
@@ -356,6 +341,22 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
 				}
 			}
 
+            if(json_scanf(event->data, event->data_len, "{ ble_scan: %B }", &booleano) == 1)
+            {
+            	if (booleano)
+            	{
+            		ESP_LOGI(TAG, "Inicio de escaneo BLE");
+            		bluetooth_start_scan();
+            		ui_set_green_led_on();
+            	}
+            	else
+            	{
+            		ESP_LOGI(TAG, "Fin de escaneo BLE");
+            		bluetooth_stop_scan();
+            		ui_set_green_led_off();
+            	}
+            }
+
 
 
         }
@@ -375,7 +376,7 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base, int32_
 
 static void mqtt_sender_task(void *pvParameters)
 {
-	char buffer[100]; //"buffer" para guardar el mensaje. Me debo asegurar que quepa...
+	char buffer[200]; //"buffer" para guardar el mensaje. Me debo asegurar que quepa...
 	char output_topic[100]; //string para el topic de salida.
 
 	while (1)
@@ -425,6 +426,30 @@ static void mqtt_sender_task(void *pvParameters)
 		    	snprintf(output_topic, sizeof(output_topic), "%s%s", MQTT_TOPIC_PUBLISH_BASE, TEMPERATURE_TOPIC);
 		    	msg_id = esp_mqtt_client_publish(client, output_topic, buffer, 0, 0, 0);
 		    	ESP_LOGI(TAG, "Temperature read sent successfully, msg_id?%d; %s", msg_id, buffer);
+		    	break;
+		    case BLUETOOTH_DEVICE:
+		    	struct json_out out6 = JSON_OUT_BUF(buffer, sizeof(buffer));
+		    	char* address;
+		    	char* rssi;
+		    	char* nombre;
+
+		    	address = strtok(msg.payload, ";");
+		    	rssi    = strtok(NULL, ";");
+		    	nombre  = strtok(NULL, ";");
+		    	ESP_LOGI(TAG, "Device scan sent successfully");
+		    	ESP_LOGI(TAG, "Los valores a imprimir son address: %s, rssi: %s, nombre: %s", address ? address : "NULO", rssi ? rssi : "NULO", nombre ? nombre : "NULO");
+
+		    	if (!nombre)
+		    	{
+		    	    json_printf(&out6," { address: \"%s\" , rssi: %s, nombre: %s } ", address, rssi, "\"Not avaliable!\"");
+		    	}
+		    	else
+		    	{
+		    		json_printf(&out6, " { address: \"%s\", rssi: %s, nombre: %s } ", address, rssi, nombre);
+		    	}
+		    	snprintf(output_topic, sizeof(output_topic), "%s%s", MQTT_TOPIC_PUBLISH_BASE, BLUETOOTH_DEVICE_TOPIC);
+				msg_id = esp_mqtt_client_publish(client, output_topic, buffer, 0, 0, 0);
+				ESP_LOGI(TAG, "Device scan sent successfully, msg_id?%d; %s", msg_id, buffer);
 		    	break;
 
 		    default:

--- a/esp32/Proyecto-MQTT/main/mqtt.c
+++ b/esp32/Proyecto-MQTT/main/mqtt.c
@@ -436,12 +436,10 @@ static void mqtt_sender_task(void *pvParameters)
 		    	address = strtok(msg.payload, ";");
 		    	rssi    = strtok(NULL, ";");
 		    	nombre  = strtok(NULL, ";");
-		    	ESP_LOGI(TAG, "Device scan sent successfully");
-		    	ESP_LOGI(TAG, "Los valores a imprimir son address: %s, rssi: %s, nombre: %s", address ? address : "NULO", rssi ? rssi : "NULO", nombre ? nombre : "NULO");
 
 		    	if (!nombre)
 		    	{
-		    	    json_printf(&out6," { address: \"%s\" , rssi: %s, nombre: %s } ", address, rssi, "\"Not avaliable!\"");
+		    	    json_printf(&out6," { address: \"%s\" , rssi: %s, nombre: %s } ", address, rssi, "\"Not available!\"");
 		    	}
 		    	else
 		    	{

--- a/esp32/Proyecto-MQTT/main/mqtt.h
+++ b/esp32/Proyecto-MQTT/main/mqtt.h
@@ -9,6 +9,36 @@
 #define MQTT_TOPIC_SUBSCRIBE_BASE      CONFIG_EXAMPLE_MQTT_TOPIC_SUBSCRIBE_BASE
 #define MQTT_TOPIC_PUBLISH_BASE  CONFIG_EXAMPLE_MQTT_TOPIC_PUBLISH_BASE
 
+//****************************************************************************
+//      TIPOS DE DATOS
+//****************************************************************************
+
+typedef enum{
+    PING,
+    BUTTON_STATUS,
+    ADC_READ,
+    LAST_WILL_MESSAGE,
+	TEMPERATURE_READ,
+	BLUETOOTH_DEVICE
+}mqtt_sendType_t;
+
+typedef enum{
+    LED_ROJO,
+    LED_VERDE,
+    LED_AZUL
+} rgb_colourIndex_t;
+
+typedef struct{
+    mqtt_sendType_t messageType;
+    char payload[128];
+}mqtt_send_t; // Tipo de datos para comunicar al hilo de envío de datos el tipo de mensaje y su payload.
+
+//*****************************************************************************
+//      VARIABLES COMPARTIDAS EXTERN
+//*****************************************************************************
+
+extern QueueHandle_t sendQueueHandler;
+
 //*****************************************************************************
 //      PROTOTIPOS DE FUNCIONES
 //*****************************************************************************

--- a/pc-interface/src/guipanel.h
+++ b/pc-interface/src/guipanel.h
@@ -19,12 +19,6 @@ class GUIPanel;
 
 //QT4:QT_USE_NAMESPACE_SERIALPORT
 
-struct BLEDeviceInfo {
-    QString name;
-    QString mac;
-    int rssi;
-};
-
 class GUIPanel : public QWidget
 {
     Q_OBJECT

--- a/pc-interface/src/guipanel.h
+++ b/pc-interface/src/guipanel.h
@@ -19,6 +19,12 @@ class GUIPanel;
 
 //QT4:QT_USE_NAMESPACE_SERIALPORT
 
+struct BLEDeviceInfo {
+    QString name;
+    QString mac;
+    int rssi;
+};
+
 class GUIPanel : public QWidget
 {
     Q_OBJECT
@@ -65,6 +71,8 @@ private slots:
 
     void on_pushButton_8_clicked(void);
 
+    void on_pushButton_9_clicked(void);
+
 private: // funciones privadas
 //    void pingDevice();
     void startClient();
@@ -82,8 +90,11 @@ private:
     bool updatingPWMControlInternally;
     bool updatingTemperatureControlInternally;
     bool adcEnable;
+    bool scanEnable;
     QString suscribeRootTopic;
     QString publishRootTopic;
+
+    QMap<QString, int> macToRowMap; // MAC -> Row index
 
     double xVal[NMAX];
     double yVal1[NMAX];

--- a/pc-interface/src/guipanel.ui
+++ b/pc-interface/src/guipanel.ui
@@ -138,7 +138,7 @@
     </rect>
    </property>
    <property name="currentIndex">
-    <number>2</number>
+    <number>0</number>
    </property>
    <widget class="QWidget" name="LED_tab">
     <attribute name="title">
@@ -515,6 +515,34 @@
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </widget>
+   <widget class="QWidget" name="tab_4">
+    <attribute name="title">
+     <string>BLE Scan</string>
+    </attribute>
+    <widget class="QTableWidget" name="tableWidget">
+     <property name="geometry">
+      <rect>
+       <x>0</x>
+       <y>0</y>
+       <width>511</width>
+       <height>221</height>
+      </rect>
+     </property>
+    </widget>
+    <widget class="QPushButton" name="pushButton_9">
+     <property name="geometry">
+      <rect>
+       <x>590</x>
+       <y>100</y>
+       <width>121</width>
+       <height>24</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Scan DISABLED</string>
      </property>
     </widget>
    </widget>


### PR DESCRIPTION
ESP32 implementation:
- Add send task queue as external variable to allow for bluetooth devices information communication.
- Add device information send capabilities via MQTT.
- Add ble scan enable/disable reception capabilities via MQTT.
- Add LCD green LED control capabilities.
- Let LCD green LED indicate ble scan status.

GUI implementation:
- Add tab to show BLE scan
- Add push button to enable/disable BLE scan.
- Add table view to show BLE devices' information.
- Format table on startup.
- Add enable/disable logic on push button click, as well as the corresponding MQTT message to send.
- Add MQTT message reception capabilities for BLE devices, including adding the information to the corresponding table row.