### PR TITLE
Fix: synchronize GUI state across multiple instances (button mode, temp, BLE)

### DIFF
--- a/pc-interface/src/guipanel.ui
+++ b/pc-interface/src/guipanel.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>759</width>
-    <height>430</height>
+    <height>437</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -207,7 +207,7 @@
        <x>10</x>
        <y>50</y>
        <width>412</width>
-       <height>197</height>
+       <height>181</height>
       </rect>
      </property>
      <layout class="QGridLayout" name="gridLayout">


### PR DESCRIPTION
- Fix descynchronisation of button mode (polling vs async) across instances.
- Prevent unintended activation of temperature acquisition when modifying the measurement time.
- Reset BLE device table across all instances when a scan is enabled on one of them.

Tested with multiple simultaneous GUI clients to confirm real-time synchronization across instances.